### PR TITLE
Add Python2-3 compatibility

### DIFF
--- a/examples/topp_example.py
+++ b/examples/topp_example.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import string, time
 from pylab import *
 from numpy import *
@@ -36,11 +37,11 @@ ret = x.RunComputeProfiles(0,0)
 x.ReparameterizeTrajectory()
 t2 = time.time()
 
-print "Using legacy:", uselegacy
-print "Discretization step:", discrtimestep
-print "Setup TOPP:", t1-t0
-print "Run TOPP:", t2-t1
-print "Total:", t2-t0
+print("Using legacy:", uselegacy)
+print("Discretization step:", discrtimestep)
+print("Setup TOPP:", t1-t0)
+print("Run TOPP:", t2-t1)
+print("Total:", t2-t0)
 
 # Display results
 ion()
@@ -53,7 +54,7 @@ x.WriteResultTrajectory()
 traj1 = Trajectory.PiecewisePolynomialTrajectory.FromString(x.restrajectorystring)
 dtplot = 0.01
 TOPPpy.PlotKinematics(traj0,traj1,dtplot,vmax,amax)
-print "Trajectory duration before TOPP: ", traj0.duration
-print "Trajectory duration after TOPP: ", traj1.duration
-print "Number of chunks in final trajectory: ", len(traj1.chunkslist)
+print("Trajectory duration before TOPP: ", traj0.duration)
+print("Trajectory duration after TOPP: ", traj1.duration)
+print("Number of chunks in final trajectory: ", len(traj1.chunkslist))
 input()

--- a/examples/topp_trajectory_call_example.py
+++ b/examples/topp_trajectory_call_example.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import print_function
 import copy, time
 
 # Ros imports
@@ -46,7 +46,7 @@ class RequestTrajectory():
         request.sampling_frequency = 100.0
         response = request_trajectory_service(request)
 
-        print "Converting trajectory to multi dof"
+        print("Converting trajectory to multi dof")
         joint_trajectory = response.trajectory
         multi_dof_trajectory = self.JointTrajectory2MultiDofTrajectory(joint_trajectory)
         trajectory_pub.publish(multi_dof_trajectory)

--- a/examples/toppra_example.py
+++ b/examples/toppra_example.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import toppra as ta
 import toppra.constraint as constraint
 import toppra.algorithm as algo
@@ -19,7 +20,7 @@ def main():
     np.random.seed(SEED)
     way_pts = np.random.randn(N_samples, dof)
     #print way_pts
-    print "SplineInterpolator"
+    print("SplineInterpolator")
     path = ta.SplineInterpolator(np.linspace(0, 1, 5), way_pts)
 
     # Create velocity bounds, then velocity constraint object

--- a/examples/toppra_multiple_robots_call_example_and_plot.py
+++ b/examples/toppra_multiple_robots_call_example_and_plot.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import print_function
 import copy, time, math
 
 # Ros imports
@@ -241,7 +241,7 @@ class RequestTrajectory():
 
 
     def generateTrajectoryCallback(self, msg):
-        print "Generating trajectory"
+        print("Generating trajectory")
         # Uav + ugv for westpoint, circular trajectory
         """
         x_uav = []
@@ -328,9 +328,9 @@ class RequestTrajectory():
         request.waypoints.joint_names = ["x_uav", "y_uav", "z_uav", "yaw_uav", "x_ugv", "y_ugv", "x_man", "y_man", "z_man", "yaw_man"]
         request.sampling_frequency = 100.0
         response = self.request_trajectory_service(request)
-        print "Total trajectory time: ", len(response.trajectory.points)/request.sampling_frequency
+        print("Total trajectory time: ", len(response.trajectory.points)/request.sampling_frequency)
 
-        print "Converting trajectory to multi dof"
+        print("Converting trajectory to multi dof")
         joint_trajectory = response.trajectory
         multi_dof_trajectory = self.jointTrajectory2MultiDofTrajectory(joint_trajectory)
         self.trajectory_pub.publish(multi_dof_trajectory)

--- a/examples/toppra_trajectory_call_example.py
+++ b/examples/toppra_trajectory_call_example.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import print_function
 import copy, time
 
 # Ros imports
@@ -73,7 +73,7 @@ class RequestTrajectory():
         # reason the trajectory was not able to be planned or the configuration
         # was incomplete or wrong it will return False.
 
-        print "Converting trajectory to multi dof"
+        print("Converting trajectory to multi dof")
         joint_trajectory = response.trajectory
         multi_dof_trajectory = self.JointTrajectory2MultiDofTrajectory(joint_trajectory)
         trajectory_pub.publish(multi_dof_trajectory)

--- a/examples/toppra_trajectory_ugv_call_example.py
+++ b/examples/toppra_trajectory_ugv_call_example.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import print_function
 import copy, time
 
 # Ros imports
@@ -42,7 +42,7 @@ class RequestTrajectory():
         request.sampling_frequency = 100.0
         response = request_trajectory_service(request)
 
-        print "Converting trajectory to multi dof"
+        print("Converting trajectory to multi dof")
         joint_trajectory = response.trajectory
         multi_dof_trajectory = self.JointTrajectory2MultiDofTrajectory(joint_trajectory)
         trajectory_pub.publish(multi_dof_trajectory)

--- a/scripts/generate_topp_trajectory.py
+++ b/scripts/generate_topp_trajectory.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import print_function
 import string, time, copy
 from pylab import *
 from numpy import *
@@ -27,14 +27,14 @@ class ToppTrajectory():
         rospy.spin()
 
     def generateToppTrajectoryCallback(self, req):
-        print "Generating TOPP trajectory."
+        print("Generating TOPP trajectory.")
         res = GenerateTrajectoryResponse()
         dof = len(req.waypoints.points[0].positions)
         n = len(req.waypoints.points)
 
         # If there is not enough waypoints to generate a trajectory return false
         if (n <= 1 or dof == 0):
-            print "You must provide at least 2 points to generate a valid trajectory."
+            print("You must provide at least 2 points to generate a valid trajectory.")
             res.trajectory.success = False
             return res
 
@@ -77,11 +77,11 @@ class ToppTrajectory():
         x.ReparameterizeTrajectory()
         t2 = time.time()
 
-        print "Using legacy:", uselegacy
-        print "Discretization step:", discrtimestep
-        print "Setup TOPP:", t1-t0
-        print "Run TOPP:", t2-t1
-        print "Total:", t2-t0
+        print("Using legacy:", uselegacy)
+        print("Discretization step:", discrtimestep)
+        print("Setup TOPP:", t1-t0)
+        print("Run TOPP:", t2-t1)
+        print("Total:", t2-t0)
 
         x.WriteProfilesList()
         x.WriteSwitchPointsList()

--- a/scripts/generate_toppra_trajectory.py
+++ b/scripts/generate_toppra_trajectory.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 # Toppra imports
 import toppra as ta
@@ -35,8 +36,8 @@ class ToppraTrajectory():
         rospy.spin()
 
     def generateToppraTrajectoryCallback(self, req):
-        print " "
-        print "Generating TOPP-RA trajectory."
+        print(" ")
+        print("Generating TOPP-RA trajectory.")
         tstart = time.time()
         res = GenerateTrajectoryResponse()
         dof = len(req.waypoints.points[0].positions)
@@ -44,7 +45,7 @@ class ToppraTrajectory():
 
         # If there is not enough waypoints to generate a trajectory return false
         if (n <= 1 or dof == 0):
-            print "You must provide at least 2 points to generate a valid trajectory."
+            print("You must provide at least 2 points to generate a valid trajectory.")
             res.trajectory.success = False
             return res
 
@@ -129,7 +130,7 @@ class ToppraTrajectory():
             res.trajectory.joint_names = copy.deepcopy(req.waypoints.joint_names)
         self.raw_trajectory_pub.publish(res.trajectory)
         self.raw_waypoints_pub.publish(req.waypoints)
-        print "Time elapsed: ", time.time()-tstart
+        print("Time elapsed: ", time.time()-tstart)
         return res
 
     def TOPPRA2JointTrajectory(self, jnt_traj, f):


### PR DESCRIPTION
Make compatibility changes according to [Cheat Sheet: Writing Python 2-3 compatible code](https://python-future.org/compatible_idioms.html).

Refactor ```print "..."``` to ```print("...")``` and add
```python
from __future__ import print_function
```
at the top of each file to ensure same behavior.